### PR TITLE
Add product review support with rating aggregation

### DIFF
--- a/prisma/migrations/20250901115522_add_review_updated_at/migration.sql
+++ b/prisma/migrations/20250901115522_add_review_updated_at/migration.sql
@@ -1,0 +1,25 @@
+/*
+  Warnings:
+
+  - Added the required column `updatedAt` to the `Review` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Review" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "rating" INTEGER NOT NULL,
+    "comment" TEXT,
+    "userId" INTEGER NOT NULL,
+    "productId" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Review_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Review_productId_fkey" FOREIGN KEY ("productId") REFERENCES "Product" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_Review" ("comment", "createdAt", "id", "productId", "rating", "userId") SELECT "comment", "createdAt", "id", "productId", "rating", "userId" FROM "Review";
+DROP TABLE "Review";
+ALTER TABLE "new_Review" RENAME TO "Review";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -87,6 +87,7 @@ model Review {
   product   Product  @relation(fields: [productId], references: [id])
   productId Int
   createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 
 // ---------- CART ----------

--- a/src/routes/products.js
+++ b/src/routes/products.js
@@ -23,9 +23,20 @@ import { Router } from "express";
  });
  router.get("/:id", async (req, res) => {
  const id = Number(req.params.id);
- const product = await prisma.product.findUnique({ where: { id } });
+ const product = await prisma.product.findUnique({
+ where: { id },
+ include: {
+ reviews: {
+ include: { user: { select: { id: true, name: true } } },
+ orderBy: { createdAt: "desc" }
+ }
+ }
+ });
  if (!product) return res.status(404).json({ error: "Not found" });
- res.json(product);
+ const averageRating = product.reviews.length
+ ? product.reviews.reduce((sum, r) => sum + r.rating, 0) / product.reviews.length
+ : null;
+ res.json({ ...product, averageRating });
  });
  const createSchema = z.object({
  title: z.string().min(1),description: z.string().optional(),

--- a/src/routes/reviews.js
+++ b/src/routes/reviews.js
@@ -1,0 +1,73 @@
+import { Router } from "express";
+import { prisma } from "../prisma.js";
+import { requireAuth } from "../middleware/auth.js";
+import { z } from "zod";
+
+const router = Router();
+
+// list reviews for a product
+router.get("/product/:productId", async (req, res) => {
+  const productId = Number(req.params.productId);
+  const reviews = await prisma.review.findMany({
+    where: { productId },
+    include: {
+      user: { select: { id: true, name: true } },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+  res.json(reviews);
+});
+
+const createSchema = z.object({
+  productId: z.number().int(),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().max(500).optional(),
+});
+
+router.post("/", requireAuth, async (req, res) => {
+  try {
+    const { productId, rating, comment } = createSchema.parse(req.body);
+    const review = await prisma.review.create({
+      data: {
+        productId,
+        rating,
+        comment: comment || null,
+        userId: req.user.id,
+      },
+    });
+    res.status(201).json(review);
+  } catch (e) {
+    res.status(400).json({ error: e.message });
+  }
+});
+
+const updateSchema = createSchema.pick({ rating: true, comment: true }).partial();
+
+router.put("/:id", requireAuth, async (req, res) => {
+  const id = Number(req.params.id);
+  try {
+    const data = updateSchema.parse(req.body);
+    const existing = await prisma.review.findUnique({ where: { id } });
+    if (!existing) return res.status(404).json({ error: "Not found" });
+    if (existing.userId !== req.user.id && req.user.role !== "ADMIN") {
+      return res.status(403).json({ error: "Forbidden" });
+    }
+    const review = await prisma.review.update({ where: { id }, data });
+    res.json(review);
+  } catch (e) {
+    res.status(400).json({ error: e.message });
+  }
+});
+
+router.delete("/:id", requireAuth, async (req, res) => {
+  const id = Number(req.params.id);
+  const existing = await prisma.review.findUnique({ where: { id } });
+  if (!existing) return res.status(404).json({ error: "Not found" });
+  if (existing.userId !== req.user.id && req.user.role !== "ADMIN") {
+    return res.status(403).json({ error: "Forbidden" });
+  }
+  await prisma.review.delete({ where: { id } });
+  res.json({ ok: true });
+});
+
+export default router;

--- a/src/server.js
+++ b/src/server.js
@@ -8,6 +8,7 @@ import productRoutes from "./routes/products.js";
 import categoryRoutes from "./routes/categories.js";
 import cartRoutes from "./routes/cart.js";
 import orderRoutes from "./routes/orders.js";
+import reviewRoutes from "./routes/reviews.js";
 
 const app = express();
 
@@ -25,6 +26,7 @@ app.use("/api/products", productRoutes);
 app.use("/api/categories", categoryRoutes);
 app.use("/api/cart", cartRoutes);
 app.use("/api/orders", orderRoutes);
+app.use("/api/reviews", reviewRoutes);
 
 app.use((err, req, res, next) => {
   console.error(err);


### PR DESCRIPTION
## Summary
- add Prisma `Review` model with timestamps
- implement CRUD API for product reviews
- include reviews and average rating when fetching a product

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_b_68b5893dbc60832aba1fb62dc2bf70f6