### PR TITLE
Add user address model and address management endpoints

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,7 +15,7 @@ model User {
   role      String    @default("USER")
   name      String
 
-  addresses Address[]
+  addresses UserAddress[]
   cart      CartItem[]
   orders    Order[]
   reviews   Review[]
@@ -32,16 +32,19 @@ model RefreshToken {
   revoked   Boolean  @default(false)
 }
 
-// ---------- ADDRESS ----------
-model Address {
-  id        Int     @id @default(autoincrement())
-  user      User    @relation(fields: [userId], references: [id])
-  userId    Int
-  street    String
-  city      String
-  country   String
-  postal    String
-  isDefault Boolean @default(false)
+// ---------- USER ADDRESS ----------
+model UserAddress {
+  id             Int     @id @default(autoincrement())
+  user           User    @relation(fields: [userId], references: [id])
+  userId         Int
+  addressLine1   String
+  addressLine2   String?
+  city           String
+  state          String
+  country        String
+  postalCode     String
+
+  orders         Order[]
 }
 
 // ---------- CATEGORY ----------
@@ -67,6 +70,7 @@ model Product {
   images    ProductImage[]
   cartItems CartItem[]
   wishlist  Wishlist[]
+  orderItems OrderItem[]
 }
 
 // ---------- PRODUCT IMAGE ----------
@@ -103,9 +107,25 @@ model CartItem {
 model Order {
   id        Int      @id @default(autoincrement())
   total     Float
-  user      User     @relation(fields: [userId], references: [id])
+  status    String   @default("PENDING")
+  user      User       @relation(fields: [userId], references: [id])
   userId    Int
+  address   UserAddress @relation(fields: [addressId], references: [id])
+  addressId Int
   createdAt DateTime @default(now())
+
+  items     OrderItem[]
+}
+
+// ---------- ORDER ITEM ----------
+model OrderItem {
+  id        Int     @id @default(autoincrement())
+  order     Order   @relation(fields: [orderId], references: [id])
+  orderId   Int
+  product   Product @relation(fields: [productId], references: [id])
+  productId Int
+  quantity  Int
+  price     Float
 }
 
 // ---------- WISHLIST ----------

--- a/src/models/user_address.js
+++ b/src/models/user_address.js
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const userAddressSchema = z.object({
+  addressLine1: z.string().min(1),
+  addressLine2: z.string().optional(),
+  city: z.string().min(1),
+  state: z.string().min(1),
+  country: z.string().min(1),
+  postalCode: z.string().min(1),
+});

--- a/src/routes/addresses.js
+++ b/src/routes/addresses.js
@@ -1,0 +1,57 @@
+import { Router } from "express";
+import { prisma } from "../prisma.js";
+import { requireAuth } from "../middleware/auth.js";
+import { userAddressSchema } from "../models/user_address.js";
+
+const router = Router();
+router.use(requireAuth);
+
+router.get("/", async (req, res) => {
+  const addresses = await prisma.userAddress.findMany({
+    where: { userId: req.user.id },
+    orderBy: { id: "asc" },
+  });
+  res.json(addresses);
+});
+
+router.post("/", async (req, res) => {
+  try {
+    const data = userAddressSchema.parse(req.body);
+    const address = await prisma.userAddress.create({
+      data: { ...data, userId: req.user.id },
+    });
+    res.status(201).json(address);
+  } catch (e) {
+    res.status(400).json({ error: e.message });
+  }
+});
+
+router.put("/:id", async (req, res) => {
+  const id = Number(req.params.id);
+  try {
+    const data = userAddressSchema.parse(req.body);
+    const existing = await prisma.userAddress.findFirst({
+      where: { id, userId: req.user.id },
+    });
+    if (!existing) return res.status(404).json({ error: "Address not found" });
+    const address = await prisma.userAddress.update({
+      where: { id },
+      data,
+    });
+    res.json(address);
+  } catch (e) {
+    res.status(400).json({ error: e.message });
+  }
+});
+
+router.delete("/:id", async (req, res) => {
+  const id = Number(req.params.id);
+  const existing = await prisma.userAddress.findFirst({
+    where: { id, userId: req.user.id },
+  });
+  if (!existing) return res.status(404).json({ error: "Address not found" });
+  await prisma.userAddress.delete({ where: { id } });
+  res.json({ ok: true });
+});
+
+export default router;

--- a/src/server.js
+++ b/src/server.js
@@ -8,6 +8,7 @@ import productRoutes from "./routes/products.js";
 import categoryRoutes from "./routes/categories.js";
 import cartRoutes from "./routes/cart.js";
 import orderRoutes from "./routes/orders.js";
+import addressRoutes from "./routes/addresses.js";
 
 const app = express();
 
@@ -25,6 +26,7 @@ app.use("/api/products", productRoutes);
 app.use("/api/categories", categoryRoutes);
 app.use("/api/cart", cartRoutes);
 app.use("/api/orders", orderRoutes);
+app.use("/api/addresses", addressRoutes);
 
 app.use((err, req, res, next) => {
   console.error(err);


### PR DESCRIPTION
## Summary
- add `UserAddress` model and link to orders
- CRUD API under `/api/addresses` for managing user addresses
- require address ID when creating orders

## Testing
- `npx prisma generate`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b5893c7778832a866c0b5206f22f40